### PR TITLE
Updated README to use develop branch badges [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The LIGO Open Science Center Python API
 
-[![Build Status](https://travis-ci.org/duncanmmacleod/python-losc.svg?branch=master)](https://travis-ci.org/duncanmmacleod/python-losc)
-[![Coverage Status](https://coveralls.io/repos/github/duncanmmacleod/python-losc/badge.svg?branch=master)](https://coveralls.io/github/duncanmmacleod/python-losc?branch=master)
+[![Build Status](https://travis-ci.org/duncanmmacleod/python-losc.svg?branch=develop)](https://travis-ci.org/duncanmmacleod/python-losc)
+[![Coverage Status](https://coveralls.io/repos/github/duncanmmacleod/python-losc/badge.svg?branch=develop)](https://coveralls.io/github/duncanmmacleod/python-losc?branch=develop)
 
 The ``losc`` package provides an interface to querying and discovering data files hosted on https://losc.ligo.org as part of the open data releases from the LIGO Scientific Collaboration.
 


### PR DESCRIPTION
This repo now uses the `git flow` method, so the `develop` branch holds the latest status of the repo, so we should use that branch for badges.