### PR TITLE
Renamed package 'gwopensci'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,10 @@
 *.swp
 
 # build files/directories to ignore
+/dist/
 /build/
 /.cache/
-/losc.egg-info/
+/*.egg-info/
 /.eggs/
 __pycache__/
 /.coverage

--- a/gwopensci/__init__.py
+++ b/gwopensci/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 # Copyright Duncan Macleod 2017
 #
-# This file is part of LOSC-Python.
+# This file is part of GWOpenSci.
 #
-# LOSC-Python is free software: you can redistribute it and/or modify
+# GWOpenSci is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LOSC-Python is distributed in the hope that it will be useful,
+# GWOpenSci is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with LOSC-Python.  If not, see <http://www.gnu.org/licenses/>.
+# along with GWOpenSci.  If not, see <http://www.gnu.org/licenses/>.
 
 from ._version import get_versions
 

--- a/gwopensci/_version.py
+++ b/gwopensci/_version.py
@@ -41,8 +41,8 @@ def get_config():
     cfg.VCS = "git"
     cfg.style = "pep440"
     cfg.tag_prefix = "v"
-    cfg.parentdir_prefix = "losc"
-    cfg.versionfile_source = "losc/_version.py"
+    cfg.parentdir_prefix = "gwopensci"
+    cfg.versionfile_source = "gwopensci/_version.py"
     cfg.verbose = False
     return cfg
 

--- a/gwopensci/api.py
+++ b/gwopensci/api.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 # Copyright Duncan Macleod 2018
 #
-# This file is part of LOSC-Python.
+# This file is part of GWOpenSci.
 #
-# LOSC-Python is free software: you can redistribute it and/or modify
+# GWOpenSci is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LOSC-Python is distributed in the hope that it will be useful,
+# GWOpenSci is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with LOSC-Python.  If not, see <http://www.gnu.org/licenses/>.
+# along with GWOpenSci.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
 import json

--- a/gwopensci/locate.py
+++ b/gwopensci/locate.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 # Copyright Duncan Macleod 2017
 #
-# This file is part of LOSC-Python.
+# This file is part of GWOpenSci.
 #
-# LOSC-Python is free software: you can redistribute it and/or modify
+# GWOpenSci is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LOSC-Python is distributed in the hope that it will be useful,
+# GWOpenSci is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with LOSC-Python.  If not, see <http://www.gnu.org/licenses/>.
+# along with GWOpenSci.  If not, see <http://www.gnu.org/licenses/>.
 
 """Locate files within a given interval on losc.ligo.org
 """

--- a/gwopensci/timeline.py
+++ b/gwopensci/timeline.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 # Copyright Duncan Macleod 2017
 #
-# This file is part of LOSC-Python.
+# This file is part of GWOpenSci.
 #
-# LOSC-Python is free software: you can redistribute it and/or modify
+# GWOpenSci is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LOSC-Python is distributed in the hope that it will be useful,
+# GWOpenSci is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with LOSC-Python.  If not, see <http://www.gnu.org/licenses/>.
+# along with GWOpenSci.  If not, see <http://www.gnu.org/licenses/>.
 
 from operator import itemgetter
 

--- a/gwopensci/urls.py
+++ b/gwopensci/urls.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 # Copyright Duncan Macleod 2018
 #
-# This file is part of LOSC-Python.
+# This file is part of GWOpenSci.
 #
-# LOSC-Python is free software: you can redistribute it and/or modify
+# GWOpenSci is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LOSC-Python is distributed in the hope that it will be useful,
+# GWOpenSci is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with LOSC-Python.  If not, see <http://www.gnu.org/licenses/>.
+# along with GWOpenSci.  If not, see <http://www.gnu.org/licenses/>.
 
 """Utilities for URL handling
 """
@@ -23,7 +23,7 @@ import os.path
 import re
 
 # LOSC filename re
-LOSC_URL_RE = re.compile(
+URL_REGEX = re.compile(
     r"\A((.*/)*(?P<obs>[^/]+)-"
     r"(?P<ifo>[A-Z][0-9])_LOSC_"
     r"((?P<tag>[^/]+)_)?"
@@ -33,7 +33,7 @@ LOSC_URL_RE = re.compile(
     r"(?P<dur>[^/\.]+)\."
     r"(?P<ext>[^/]+))\Z"
 )
-LOSC_VERSION_RE = re.compile(r'V\d+')
+VERSION_REGEX = re.compile(r'V\d+')
 
 
 def sieve(urllist, **match):
@@ -67,7 +67,7 @@ def _match_url(url, start=None, end=None, tag=None, version=None):
         if the start time of the URL is _after_ the end time of the
         request
     """
-    reg = LOSC_URL_RE.match(os.path.basename(url)).groupdict()
+    reg = URL_REGEX.match(os.path.basename(url)).groupdict()
     if (tag and reg['tag'] != tag) or (version and reg['version'] != version):
         return
 
@@ -120,7 +120,7 @@ def match(urls, start=None, end=None, tag=None, version=None):
               os.path.splitext(os.path.basename(u))[0].split('-')[::-1])
 
     # format version request
-    if version and not LOSC_VERSION_RE.match(str(version)):
+    if version and not VERSION_REGEX.match(str(version)):
         version = 'V{}'.format(int(version))
 
     # loop URLS

--- a/gwopensci/utils.py
+++ b/gwopensci/utils.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 # Copyright Duncan Macleod 2017
 #
-# This file is part of LOSC-Python.
+# This file is part of GWOpenSci.
 #
-# LOSC-Python is free software: you can redistribute it and/or modify
+# GWOpenSci is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LOSC-Python is distributed in the hope that it will be useful,
+# GWOpenSci is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with LOSC-Python.  If not, see <http://www.gnu.org/licenses/>.
+# along with GWOpenSci.  If not, see <http://www.gnu.org/licenses/>.
 
 from os.path import basename
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,16 +4,16 @@ test = pytest
 [versioneer]
 VCS = git
 style = pep440
-versionfile_source = losc/_version.py
-versionfile_build = losc/_version.py
+versionfile_source = gwopensci/_version.py
+versionfile_build = gwopensci/_version.py
 tag_prefix = v
-parentdir_prefix = losc
+parentdir_prefix = gwopensci
 
 [tool:pytest]
 addopts = --verbose -r s
 
 [coverage:run]
-source = losc
+source = gwopensci
 omit =
-	losc/_version.py
-	losc/test_losc.py
+	gwopensci/_version.py
+	gwopensci/test_gwopensci.py

--- a/setup.py
+++ b/setup.py
@@ -2,22 +2,22 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) Duncan Macleod (2017)
 #
-# This file is part of LOSC-Python.
+# This file is part of GWOpenSci
 #
-# LOSC-Python is free software: you can redistribute it and/or modify
+# GWOpenSci is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LOSC-Python is distributed in the hope that it will be useful,
+# GWOpenSci is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with LOSC-Python.  If not, see <http://www.gnu.org/licenses/>.
+# along with GWOpenSci.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Setup the LOSC-Python package
+"""Setup the GWOpenSci package
 """
 
 import sys
@@ -35,10 +35,10 @@ else:
     setup_requires = []
 
 # run setup
-setup(name='losc',
+setup(name='gwopensci',
       version=__version__,
-      packages=['losc'],
-      description="A python interface to the LOSC data archive",
+      packages=['gwopensci'],
+      description="A python interface to the GW Open Science data archive",
       author='Duncan Macleod',
       author_email='duncan.macleod@ligo.org',
       license='MIT',
@@ -49,8 +49,9 @@ setup(name='losc',
       tests_require=['pytest>=2.8'],
       cmdclass=versioneer.get_cmdclass(),
       classifiers=[
-          'Development Status :: 3 - Alpha',
+          'Development Status :: 4 - Beta',
           'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.3',
@@ -64,4 +65,4 @@ setup(name='losc',
           'Topic :: Scientific/Engineering :: Physics',
           'License :: OSI Approved :: MIT License',
       ],
-      )
+)


### PR DESCRIPTION
This PR renames the `losc` python package `gwopensci`, so that the name isn't LIGO specific. This will required renaming the whole github repo as well, for the record.

cc: @duncan-brown, @ecm0, @jkanner