### PR TITLE
Fixed lingering reference to 'losc' in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include versioneer.py
-include losc/_version.py
+include gwopensci/_version.py


### PR DESCRIPTION
This PR fixes a lingering reference to `losc` in `MANIFEST.in`.