### PR TITLE
Renamed default URL to DEFAULT_URL

### DIFF
--- a/gwopensci/api.py
+++ b/gwopensci/api.py
@@ -21,7 +21,7 @@ import json
 
 from six.moves.urllib.request import urlopen
 
-LOSC_URL = 'https://losc.ligo.org'
+DEFAULT_URL = 'https://losc.ligo.org'
 MAX_GPS = 99999999999
 
 
@@ -64,7 +64,7 @@ def fetch_json(url):
 
 # -- API calls ----------------------------------------------------------------
 
-def fetch_dataset_json(gpsstart, gpsend, host=LOSC_URL):
+def fetch_dataset_json(gpsstart, gpsend, host=DEFAULT_URL):
     """Returns the JSON metadata for all datasets matching the GPS interval
 
     Parameters
@@ -87,7 +87,7 @@ def fetch_dataset_json(gpsstart, gpsend, host=LOSC_URL):
     return fetch_json(url)
 
 
-def fetch_event_json(event, host=LOSC_URL):
+def fetch_event_json(event, host=DEFAULT_URL):
     """Returns the JSON metadata for the given event
 
     Parameters
@@ -107,7 +107,8 @@ def fetch_event_json(event, host=LOSC_URL):
     return fetch_json(url)
 
 
-def fetch_run_json(run, detector, gpsstart=0, gpsend=MAX_GPS, host=LOSC_URL):
+def fetch_run_json(run, detector, gpsstart=0, gpsend=MAX_GPS,
+                   host=DEFAULT_URL):
     """Returns the JSON metadata for the given science run parameters
 
     Parameters

--- a/gwopensci/locate.py
+++ b/gwopensci/locate.py
@@ -19,8 +19,6 @@
 """Locate files within a given interval on losc.ligo.org
 """
 
-from six.moves.urllib.request import urlopen
-
 from . import (api, urls as lurls, utils)
 
 __all__ = ['get_urls', 'get_event_urls']

--- a/gwopensci/locate.py
+++ b/gwopensci/locate.py
@@ -27,7 +27,7 @@ __all__ = ['get_urls', 'get_event_urls']
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
-def get_urls(detector, start, end, host=api.LOSC_URL,
+def get_urls(detector, start, end, host=api.DEFAULT_URL,
              tag=None, version=None, sample_rate=4096, format='hdf5'):
     """Fetch the metadata from LOSC regarding a given GPS interval
 
@@ -106,7 +106,7 @@ def get_urls(detector, start, end, host=api.LOSC_URL,
 
 
 def get_event_urls(event, format='hdf5', sample_rate=4096, **match):
-    meta = api.fetch_event_json(event, host=match.pop('host', api.LOSC_URL))
+    meta = api.fetch_event_json(event, host=match.pop('host', api.DEFAULT_URL))
     sieve_kw = {k: match.pop(k) for k in list(match.keys()) if
                 k not in {'start', 'end', 'tag', 'version'}}
     return lurls.match(

--- a/gwopensci/timeline.py
+++ b/gwopensci/timeline.py
@@ -22,7 +22,7 @@ from . import api
 from .urls import sieve
 
 
-def get_segments(flag, start, end, host=api.LOSC_URL):
+def get_segments(flag, start, end, host=api.DEFAULT_URL):
     """Return the [start, end) GPS segments for this flag
 
     Parameters
@@ -48,7 +48,7 @@ def get_segments(flag, start, end, host=api.LOSC_URL):
         timeline_url(flag, start, end, host=host))['segments']))
 
 
-def timeline_url(flag, start, end, host=api.LOSC_URL):
+def timeline_url(flag, start, end, host=api.DEFAULT_URL):
     """Returns the Timeline JSON URL for a flag name and GPS interval
     """
     detector = flag.split('_', 1)[0]
@@ -57,7 +57,7 @@ def timeline_url(flag, start, end, host=api.LOSC_URL):
         host, dataset, flag, start, end-start)
 
 
-def _find_dataset(start, end, detector, host=api.LOSC_URL):
+def _find_dataset(start, end, detector, host=api.DEFAULT_URL):
     meta = api.fetch_dataset_json(start, end, host=host)
     span = (start, end)
     duration = end-start
@@ -95,7 +95,7 @@ def _find_dataset(start, end, detector, host=api.LOSC_URL):
     return sorted(epochs, key=itemgetter(1, 0))[0][0]
 
 
-def _event_segment(event, host=api.LOSC_URL, **match):
+def _event_segment(event, host=api.DEFAULT_URL, **match):
     jdata = api.fetch_event_json(event, host=host)
     seg = None
     for fmeta in sieve(jdata['strain'], **match):

--- a/gwopensci/timeline.py
+++ b/gwopensci/timeline.py
@@ -59,7 +59,6 @@ def timeline_url(flag, start, end, host=api.DEFAULT_URL):
 
 def _find_dataset(start, end, detector, host=api.DEFAULT_URL):
     meta = api.fetch_dataset_json(start, end, host=host)
-    span = (start, end)
     duration = end-start
 
     epochs = []


### PR DESCRIPTION
This PR renames the `gwopensci.api.LOSC_URL` variable to `gwopensci.api.DEFAULT_URL` - this should have been included as part of #4, but was missed.