### PR TITLE
Added marks for tests to allow testing in packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ build:debian: &build-debian
         python3-six \
         python-pytest \
         python3-pytest \
+        python-mock \
         python-pip \
         python3-pip \
         python-pytest-cov \
@@ -49,6 +50,7 @@ build:centos: &build-centos
         python34-six \
         python2-pytest \
         python34-pytest \
+        python2-mock \
         python2-pip \
         python34-pip \
         python2-pytest-cov \

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,8 @@ Build-Depends: debhelper (>= 9),
                python-six,
                python3-six,
                python-pytest,
-               python3-pytest
+               python3-pytest,
+               python-mock,
 
 # -- python-gwosc --------------------------------------------------------------
 

--- a/debian/rules
+++ b/debian/rules
@@ -2,5 +2,10 @@
 
 export PYBUILD_NAME = gwosc
 
+# use pytest for tests
+export PYBUILD_TEST_PYTEST = 1
+# but don't run tests requiring network
+export PYBUILD_TEST_ARGS = -m 'not remote'
+
 %:
 	dh $@ --with python2,python3 --buildsystem=pybuild

--- a/gwosc.spec
+++ b/gwosc.spec
@@ -61,8 +61,8 @@ gravitational-wave observatories.
 %py3_build
 
 %check
-%{__python2} -m pytest --pyargs %{name}
-%{__python3} -m pytest --pyargs %{name}
+%{__python2} -m pytest --pyargs %{name} -m "not remote"
+%{__python3} -m pytest --pyargs %{name} -m "not remote"
 
 %install
 %py2_install

--- a/gwosc.spec
+++ b/gwosc.spec
@@ -23,6 +23,7 @@ BuildRequires: python2-six
 BuildRequires: python%{python3_pkgversion}-six
 BuildRequires: python2-pytest
 BuildRequires: python%{python3_pkgversion}-pytest
+BuildRequires: python2-mock
 
 %description
 The `gwosc` package provides an interface to querying the open data

--- a/gwosc/tests/test_api.py
+++ b/gwosc/tests/test_api.py
@@ -88,6 +88,7 @@ def test_fetch_dataset_json_local(fetch):
     fetch.assert_called_with(
         losc_url('archive/{0}/{1}/json/'.format(start, end)))
 
+
 @pytest.mark.remote
 def test_fetch_event_json():
     event = 'GW150914'
@@ -95,6 +96,7 @@ def test_fetch_event_json():
     assert int(out['GPS']) == 1126259462
     assert out['dataset'] == event
     check_json_url_list(out['strain'])
+
 
 @pytest.mark.local
 @mock.patch('gwosc.api.fetch_json')

--- a/gwosc/tests/test_api.py
+++ b/gwosc/tests/test_api.py
@@ -35,6 +35,7 @@ def check_json_url_list(urllist, keys={'detector', 'format', 'url'}):
             assert key in urld
 
 
+@pytest.mark.remote
 def test_fetch_json():
     url = 'https://losc.ligo.org/archive/1126257414/1126261510/json/'
     out = api.fetch_json(url)
@@ -51,6 +52,7 @@ def test_fetch_json():
         "Failed to parse LOSC JSON from {!r}: ".format(url2))
 
 
+@pytest.mark.remote
 def test_fetch_dataset_json():
     start = 934000000
     end = 934100000
@@ -59,6 +61,7 @@ def test_fetch_dataset_json():
     assert set(out['runs'].keys()) == {'tenyear', 'S6'}
 
 
+@pytest.mark.remote
 def test_fetch_event_json():
     event = 'GW150914'
     out = api.fetch_event_json(event)
@@ -67,6 +70,7 @@ def test_fetch_event_json():
     check_json_url_list(out['strain'])
 
 
+@pytest.mark.remote
 def test_fetch_run_json():
     run = 'S6'
     detector = 'L1'

--- a/gwosc/tests/test_api.py
+++ b/gwosc/tests/test_api.py
@@ -33,6 +33,7 @@ from .. import api
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
+
 def losc_url(path):
     return '{0}/{1}'.format(api.DEFAULT_URL, path)
 

--- a/gwosc/tests/test_datasets.py
+++ b/gwosc/tests/test_datasets.py
@@ -20,6 +20,10 @@
 """
 
 import re
+try:
+    from unittest import mock
+except ImportError:  # python < 3
+    import mock
 
 import pytest
 
@@ -51,12 +55,43 @@ def test_find_datasets():
         datasets.find_datasets(type='badtype')
 
 
+@pytest.mark.local
+@mock.patch('gwosc.api.fetch_dataset_json', return_value={
+    'runs': {
+        'S6': {'detectors': ['H1', 'L1', 'V1']},
+        'tenyear': None,
+    },
+    'events': {
+        'GW150914': {'detectors': ['H1', 'L1']},
+    }
+})
+def test_find_datasets_local(fetch):
+    sets = datasets.find_datasets()
+    assert datasets.find_datasets() == ['GW150914', 'S6']
+    assert datasets.find_datasets(detector='V1') == ['S6']
+    assert datasets.find_datasets(type='event') == ['GW150914']
+    assert datasets.find_datasets(type='event', detector='V1') == []
+
+
 @pytest.mark.remote
 def test_event_gps():
     assert datasets.event_gps('GW170817') == 1187008882.43
     with pytest.raises(ValueError) as exc:
         datasets.event_gps('GW123456')
     assert str(exc.value) == 'no event dataset found for \'GW123456\''
+
+
+@pytest.mark.local
+@mock.patch('gwosc.api.fetch_event_json', return_value={
+    'GPS': 12345,
+    'something else': None,
+})
+def test_event_gps_local(fetch):
+    assert datasets.event_gps('GW150914') == 12345
+    fetch.side_effect = ValueError('test')
+    with pytest.raises(ValueError) as exc:
+        datasets.event_gps('something')
+    assert str(exc.value) == 'no event dataset found for \'something\''
 
 
 @pytest.mark.remote
@@ -67,6 +102,19 @@ def test_event_at_gps():
     assert str(exc.value) == 'no event found within 0.1 seconds of 1187008882'
 
 
+@pytest.mark.local
+@mock.patch('gwosc.api.fetch_dataset_json', return_value={
+    'events': {
+        'GW150914': {'GPStime': 12345},
+        'GW151226': {'GPStime': 12347},
+    },
+})
+def test_event_at_gps_local(fetch):
+    assert datasets.event_at_gps(12345) == 'GW150914'
+    with pytest.raises(ValueError):
+        datasets.event_at_gps(12349)
+
+
 @pytest.mark.remote
 def test_run_segment():
     assert datasets.run_segment('O1') == (1126051217, 1137254417)
@@ -75,9 +123,33 @@ def test_run_segment():
     assert str(exc.value) == 'no run dataset found for \'S7\''
 
 
+@pytest.mark.local
+@mock.patch('gwosc.api.fetch_dataset_json', return_value={
+    'runs': {
+        'S1': {'GPSstart': 0, 'GPSend': 1},
+    },
+})
+def test_run_segment_local(fetch):
+    assert datasets.run_segment('S1') == (0, 1)
+    with pytest.raises(ValueError) as exc:
+        datasets.run_segment('S2')
+
+
 @pytest.mark.remote
 def test_run_at_gps():
     assert datasets.run_at_gps(1135136350) in {'O1', 'O1_16KHZ'}
     with pytest.raises(ValueError) as exc:
         datasets.run_at_gps(0)
     assert str(exc.value) == 'no run dataset found containing GPS 0'
+
+
+@pytest.mark.local
+@mock.patch('gwosc.api.fetch_dataset_json', return_value={
+    'runs': {
+        'S1': {'GPSstart': 0, 'GPSend': 1},
+    },
+})
+def test_run_at_gps_local(fetch):
+    assert datasets.run_at_gps(0) == 'S1'
+    with pytest.raises(ValueError):
+        datasets.run_at_gps(10)

--- a/gwosc/tests/test_datasets.py
+++ b/gwosc/tests/test_datasets.py
@@ -32,6 +32,18 @@ from .. import datasets
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+DATASET_JSON = {
+    'events': {
+        'GW150914': {'GPStime': 12345, 'detectors': ['H1', 'L1']},
+        'GW151226': {'GPStime': 12347, 'detectors': ['H1', 'L1']},
+    },
+    'runs': {
+        'S1': {'GPSstart': 0, 'GPSend': 1, 'detectors': ['H1', 'L1', 'V1']},
+        'tenyear': None,
+    },
+}
+
+
 @pytest.mark.remote
 def test_find_datasets():
     sets = datasets.find_datasets()
@@ -56,20 +68,12 @@ def test_find_datasets():
 
 
 @pytest.mark.local
-@mock.patch('gwosc.api.fetch_dataset_json', return_value={
-    'runs': {
-        'S6': {'detectors': ['H1', 'L1', 'V1']},
-        'tenyear': None,
-    },
-    'events': {
-        'GW150914': {'detectors': ['H1', 'L1']},
-    }
-})
+@mock.patch('gwosc.api.fetch_dataset_json', return_value=DATASET_JSON)
 def test_find_datasets_local(fetch):
     sets = datasets.find_datasets()
-    assert datasets.find_datasets() == ['GW150914', 'S6']
-    assert datasets.find_datasets(detector='V1') == ['S6']
-    assert datasets.find_datasets(type='event') == ['GW150914']
+    assert datasets.find_datasets() == ['GW150914', 'GW151226', 'S1']
+    assert datasets.find_datasets(detector='V1') == ['S1']
+    assert datasets.find_datasets(type='event') == ['GW150914', 'GW151226']
     assert datasets.find_datasets(type='event', detector='V1') == []
 
 
@@ -103,12 +107,7 @@ def test_event_at_gps():
 
 
 @pytest.mark.local
-@mock.patch('gwosc.api.fetch_dataset_json', return_value={
-    'events': {
-        'GW150914': {'GPStime': 12345},
-        'GW151226': {'GPStime': 12347},
-    },
-})
+@mock.patch('gwosc.api.fetch_dataset_json', return_value=DATASET_JSON)
 def test_event_at_gps_local(fetch):
     assert datasets.event_at_gps(12345) == 'GW150914'
     with pytest.raises(ValueError):
@@ -124,11 +123,7 @@ def test_run_segment():
 
 
 @pytest.mark.local
-@mock.patch('gwosc.api.fetch_dataset_json', return_value={
-    'runs': {
-        'S1': {'GPSstart': 0, 'GPSend': 1},
-    },
-})
+@mock.patch('gwosc.api.fetch_dataset_json', return_value=DATASET_JSON)
 def test_run_segment_local(fetch):
     assert datasets.run_segment('S1') == (0, 1)
     with pytest.raises(ValueError) as exc:
@@ -144,11 +139,7 @@ def test_run_at_gps():
 
 
 @pytest.mark.local
-@mock.patch('gwosc.api.fetch_dataset_json', return_value={
-    'runs': {
-        'S1': {'GPSstart': 0, 'GPSend': 1},
-    },
-})
+@mock.patch('gwosc.api.fetch_dataset_json', return_value=DATASET_JSON)
 def test_run_at_gps_local(fetch):
     assert datasets.run_at_gps(0) == 'S1'
     with pytest.raises(ValueError):

--- a/gwosc/tests/test_datasets.py
+++ b/gwosc/tests/test_datasets.py
@@ -28,6 +28,7 @@ from .. import datasets
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+@pytest.mark.remote
 def test_find_datasets():
     sets = datasets.find_datasets()
     for dset in ('S6', 'O1', 'GW150914', 'GW170817'):
@@ -50,6 +51,7 @@ def test_find_datasets():
         datasets.find_datasets(type='badtype')
 
 
+@pytest.mark.remote
 def test_event_gps():
     assert datasets.event_gps('GW170817') == 1187008882.43
     with pytest.raises(ValueError) as exc:
@@ -57,6 +59,7 @@ def test_event_gps():
     assert str(exc.value) == 'no event dataset found for \'GW123456\''
 
 
+@pytest.mark.remote
 def test_event_at_gps():
     assert datasets.event_at_gps(1187008882) == 'GW170817'
     with pytest.raises(ValueError) as exc:
@@ -64,6 +67,7 @@ def test_event_at_gps():
     assert str(exc.value) == 'no event found within 0.1 seconds of 1187008882'
 
 
+@pytest.mark.remote
 def test_run_segment():
     assert datasets.run_segment('O1') == (1126051217, 1137254417)
     with pytest.raises(ValueError) as exc:
@@ -71,6 +75,7 @@ def test_run_segment():
     assert str(exc.value) == 'no run dataset found for \'S7\''
 
 
+@pytest.mark.remote
 def test_run_at_gps():
     assert datasets.run_at_gps(1135136350) in {'O1', 'O1_16KHZ'}
     with pytest.raises(ValueError) as exc:

--- a/gwosc/tests/test_locate.py
+++ b/gwosc/tests/test_locate.py
@@ -32,6 +32,7 @@ from .. import (
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+@pytest.mark.remote
 def test_get_urls():
     # test simple fetch for S6 data returns only files within segment
     detector = 'L1'
@@ -55,6 +56,7 @@ def test_get_urls():
         locate.get_urls('V1', start, end)
 
 
+@pytest.mark.remote
 def test_get_event_urls(gw150914_urls):
     # find latest version by brute force
     latestv = sorted(

--- a/gwosc/tests/test_timeline.py
+++ b/gwosc/tests/test_timeline.py
@@ -26,6 +26,7 @@ from .. import timeline
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+@pytest.mark.remote
 @pytest.mark.parametrize('flag, start, end, result', [
     ('H1_DATA', 1126051217, 1126151217, [
         (1126073529, 1126114861),
@@ -42,6 +43,7 @@ def test_get_segments(flag, start, end, result):
     assert timeline.get_segments(flag, start, end) == result
 
 
+@pytest.mark.remote
 def test_timeline_url():
     # check that unknown IFO results in no matches
     with pytest.raises(ValueError):

--- a/gwosc/tests/test_timeline.py
+++ b/gwosc/tests/test_timeline.py
@@ -19,6 +19,11 @@
 """Tests for :mod:`gwosc.timeline`
 """
 
+try:
+    from unittest import mock
+except ImportError:  # python < 3
+    import mock
+
 import pytest
 
 from .. import timeline
@@ -48,3 +53,11 @@ def test_timeline_url():
     # check that unknown IFO results in no matches
     with pytest.raises(ValueError):
         timeline.timeline_url('X1', 1126259446, 1126259478)
+
+
+@pytest.mark.local
+@mock.patch('gwosc.timeline._find_dataset', return_value='S6')
+def test_timeline_url_local(find):
+    assert timeline.timeline_url('L1_DATA', 0, 1, host='test') == (
+        'test/timeline/segments/json/S6/L1_DATA/0/1/')
+    find.assert_called_with(0, 1, 'L1', host='test')

--- a/gwosc/tests/test_urls.py
+++ b/gwosc/tests/test_urls.py
@@ -69,10 +69,10 @@ def test_match(gw150914_urls, gw170817_urls):
 URLS = [
     {'url': 'X-X1_LOSC_TEST_4_V1-0-1.ext',
      'detector': 'X1',
-     'sampling_rate': 100,},
+     'sampling_rate': 100},
     {'url': 'Y-Y1_LOSC_TEST_16_V2-1-1.ext',
      'detector': 'Y1',
-     'sampling_rate': 200,},
+     'sampling_rate': 200},
 ]
 
 

--- a/gwosc/tests/test_urls.py
+++ b/gwosc/tests/test_urls.py
@@ -26,6 +26,7 @@ from .. import urls as gwosc_urls
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+@pytest.mark.remote
 def test_sieve(gw150914_urls):
     nfiles = len(gw150914_urls)
     sieved = list(gwosc_urls.sieve(gw150914_urls, detector='L1'))
@@ -38,6 +39,7 @@ def test_sieve(gw150914_urls):
         list(gwosc_urls.sieve(gw150914_urls, blah=None))
 
 
+@pytest.mark.remote
 def test_match(gw150914_urls, gw170817_urls):
     urls = [u['url'] for u in gw150914_urls]
     nfiles = len(urls)

--- a/gwosc/tests/test_urls.py
+++ b/gwosc/tests/test_urls.py
@@ -61,3 +61,29 @@ def test_match(gw150914_urls, gw170817_urls):
     assert not gwosc_urls.match(urls, tag='BLAH')
     assert not gwosc_urls.match(urls, start=1e12)
     assert not gwosc_urls.match(urls, end=0)
+
+
+# -- local tests
+
+
+URLS = [
+    {'url': 'X-X1_LOSC_TEST_4_V1-0-1.ext',
+     'detector': 'X1',
+     'sampling_rate': 100,},
+    {'url': 'Y-Y1_LOSC_TEST_16_V2-1-1.ext',
+     'detector': 'Y1',
+     'sampling_rate': 200,},
+]
+
+
+@pytest.mark.local
+def test_sieve_local():
+    assert list(gwosc_urls.sieve(URLS, detector='X1')) == URLS[:1]
+    assert list(gwosc_urls.sieve(URLS, sample_rate=200)) == URLS[1:]
+
+
+@pytest.mark.local
+def test_match_local():
+    urls = [u['url'] for u in URLS]
+    assert gwosc_urls.match(urls, start=0, end=1) == urls[:1]
+    assert gwosc_urls.match(urls, version=2) == urls[1:]

--- a/gwosc/tests/test_utils.py
+++ b/gwosc/tests/test_utils.py
@@ -41,6 +41,7 @@ def test_url_overlaps_segment(url, segment, result):
     assert utils.url_overlaps_segment(url, segment) is result
 
 
+@pytest.mark.remote
 @pytest.mark.parametrize('segment, result', [
     ((1126257414, 1126257414+4096), True),
     ((1126257413, 1126257414+4096), False),

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ parentdir_prefix = gwosc
 
 [tool:pytest]
 addopts = -r s
+markers =
+	remote
+	local
 
 [coverage:run]
 source = gwosc

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     license='MIT',
     setup_requires=setup_requires,
     install_requires=['six>=1.9.0'],
-    tests_require=['pytest>=2.8'],
+    tests_require=['pytest>=2.8', 'mock ; python_version < '3';'],
     extras_require={
         'docs': ['sphinx', 'sphinx_rtd_theme', 'numpydoc'],
     },

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,25 @@ import versioneer
 
 __version__ = versioneer.get_version()
 
-# setup dependencies for testing (only if we are actually testing)
-if set(('test',)).intersection(sys.argv):
-    setup_requires = ['pytest_runner']
-else:
-    setup_requires = []
+# dependencies
+setup_requires = []
+if {'test'}.intersection(sys.argv):
+    setup_requires.append('pytest_runner')
+install_requires = [
+    'six>=1.9.0',
+]
+tests_require = [
+    'pytest>=2.8',
+]
+if sys.version_info.major < 3:
+    tests_require.append('mock')
+extras_require = {
+    'docs': [
+        'sphinx',
+        'sphinx_rtd_theme',
+        'numpydoc',
+    ],
+}
 
 # get long description from README
 with open('README.md', 'rb') as f:
@@ -40,9 +54,9 @@ with open('README.md', 'rb') as f:
 
 # run setup
 setup(
+    # metadata
     name='gwosc',
     version=__version__,
-    packages=find_packages(),
     description="A python interface to the GW Open Science data archive",
     long_description=longdesc,
     long_description_content_type='text/markdown',
@@ -50,13 +64,6 @@ setup(
     author_email='duncan.macleod@ligo.org',
     url='https://github.com/gwpy/gwosc',
     license='MIT',
-    setup_requires=setup_requires,
-    install_requires=['six>=1.9.0'],
-    tests_require=['pytest>=2.8', 'mock ; python_version < '3';'],
-    extras_require={
-        'docs': ['sphinx', 'sphinx_rtd_theme', 'numpydoc'],
-    },
-    cmdclass=versioneer.get_cmdclass(),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',
@@ -73,4 +80,13 @@ setup(
         'Topic :: Scientific/Engineering :: Physics',
         'License :: OSI Approved :: MIT License',
     ],
+    # build
+    cmdclass=versioneer.get_cmdclass(),
+    # content
+    packages=find_packages(),
+    # dependencies
+    setup_requires=setup_requires,
+    install_requires=install_requires,
+    tests_require=tests_require,
+    extras_require=extras_require,
 )


### PR DESCRIPTION
This PR introduces marks for all test functions, declaring all of the existing functions as `remote`, and adding a few new `local` tests. The EL7 and Debian packaging has then been modified to only run the `local` tests during build.

This enables some half-decent testing to be done during the packaging, which is nice, and should enable easier distinction between internal failures, and upstream changes from GWOSC.

This replaces #23, which was opened from the wrong fork.