### PR TITLE
Added a dataset_type method

### DIFF
--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -371,3 +371,38 @@ def run_at_gps(gps, host=api.DEFAULT_URL):
         if start <= gps < end:
             return run
     raise ValueError("no run dataset found containing GPS {0}".format(gps))
+
+
+def dataset_type(dataset, host=api.DEFAULT_URL):
+    """Returns the type of the named dataset
+
+    Parameters
+    ----------
+    dataset : `str`
+        The name of the dataset to match
+
+    host : `str`, optional
+        the URL of the LOSC host to query
+
+    Returns
+    -------
+    type : `str`
+        the type of the dataset, one of 'run', 'event', or 'catalog'
+
+    Raises
+    -------
+    ValueError
+        if this dataset cannot be matched
+
+    Examples
+    --------
+    >>> from gwosc.datasets import dataset_type
+    >>> dataset_type('O1')
+    'run'
+    """
+    for type_ in ("run", "catalog", "event"):
+        if dataset in find_datasets(type=type_):
+            return type_
+    raise ValueError(
+        "failed to determine type for dataset {0!r}".format(dataset),
+    )

--- a/gwosc/locate.py
+++ b/gwosc/locate.py
@@ -96,6 +96,10 @@ def get_urls(
          ),
     ]
 
+    if dataset:
+        dstype = datasets.dataset_type(dataset)
+        dataset_metadata = [(dstype, dict(dataset_metadata)[dstype])]
+
     for dstype, _get_urls in dataset_metadata:
         if dataset:
             dsets = [dataset]

--- a/gwosc/tests/test_datasets.py
+++ b/gwosc/tests/test_datasets.py
@@ -222,3 +222,22 @@ def test_run_at_gps_local(fetch):
     assert datasets.run_at_gps(0) == 'S1'
     with pytest.raises(ValueError):
         datasets.run_at_gps(10)
+
+
+@pytest.mark.remote
+def test_dataset_type():
+    assert datasets.dataset_type("O1") == "run"
+    assert datasets.dataset_type("GW150914") == "event"
+    assert datasets.dataset_type("GWTC-1-confident") == "catalog"
+    with pytest.raises(ValueError):
+        datasets.dataset_type("invalid")
+
+
+@mock.patch(
+    'gwosc.datasets.find_datasets',
+    side_effect=[["testrun"], [],  ["testevent"], [], [], []],
+)
+def test_dataset_type_local(find):
+    assert datasets.dataset_type("testevent") == "event"
+    with pytest.raises(ValueError):
+        datasets.dataset_type("invalid")


### PR DESCRIPTION
This PR adds a `gwosc.datasets.dataset_type` method to resolve the type of a dataset from its name.