### PR TITLE
Fixed overwrite of variable name in get_urls

### DIFF
--- a/gwosc/locate.py
+++ b/gwosc/locate.py
@@ -110,9 +110,9 @@ def get_urls(
                 segment=(start, end),
                 host=host,
             )
-        for dataset in dsets:
+        for dst in dsets:
             # get URL list for this dataset
-            urls = _get_urls(dataset)["strain"]
+            urls = _get_urls(dst)["strain"]
 
             # match URLs to request
             urls = lurls.match(

--- a/gwosc/tests/test_locate.py
+++ b/gwosc/tests/test_locate.py
@@ -53,6 +53,9 @@ def test_get_urls():
         dataset="GW170817",
     )) == 2
 
+    # test for O1 data
+    assert len(locate.get_urls("L1", 1135136228, 1135140324)) == 2
+
     # assert no hits raises exception
     with pytest.raises(ValueError):  # no data in 1980
         locate.get_urls(detector, 0, 1)


### PR DESCRIPTION
This PR fixes a critical bug in `gwosc.locate.get_urls`.