### PR TITLE
Fixed some bugs in the timeline API

### DIFF
--- a/gwosc/tests/test_timeline.py
+++ b/gwosc/tests/test_timeline.py
@@ -48,6 +48,7 @@ def test_get_segments(flag, start, end, result):
     assert timeline.get_segments(flag, start, end) == result
 
 
+@pytest.mark.remote
 def test_get_segments_long():
     assert len(timeline.get_segments('H1_DATA', 1126051217, 1137196817)) == 654
 

--- a/gwosc/tests/test_timeline.py
+++ b/gwosc/tests/test_timeline.py
@@ -48,6 +48,10 @@ def test_get_segments(flag, start, end, result):
     assert timeline.get_segments(flag, start, end) == result
 
 
+def test_get_segments_long():
+    assert len(timeline.get_segments('H1_DATA', 1126051217, 1137196817)) == 654
+
+
 @pytest.mark.remote
 def test_timeline_url():
     # check that unknown IFO results in no matches

--- a/gwosc/timeline.py
+++ b/gwosc/timeline.py
@@ -64,7 +64,7 @@ def _find_dataset(start, end, detector, host=api.DEFAULT_URL):
         versions = api._find_catalog_event_versions(event, host=host)
         last = versions[-1]
         dataset = "{0}_R{1}".format(event, last)
-        metadata = api.fetch_event_json(event, host=host)
+        metadata = api.fetch_event_json(dataset, host=host)
         return (
             dataset,
             utils.urllist_extent(map(itemgetter("url"), metadata["strain"])),
@@ -91,7 +91,14 @@ def _find_dataset(start, end, detector, host=api.DEFAULT_URL):
             host=host,
         )
         for dataset in dsets:
-            dataset, segment = _dataset_segment(dataset)
+            try:
+                dataset, segment = _dataset_segment(dataset)
+            except ValueError as exc:
+                if str(exc) == (
+                    "no event datasets found for {!r}".format(dataset)
+                ):
+                    continue
+                raise
             overlap = min(end, segment[1]) - max(start, segment[0])
             epochs.append((dataset, duration-overlap))
 


### PR DESCRIPTION
This PR fixes some bugs in the `gwosc.timeline` API exposed by gwpy examples.