### PR TITLE
Added match keyword to find_datasets

### DIFF
--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -22,6 +22,7 @@ Note: each of these methods deliberately excludes the 'tenyear' dataset.
 """
 
 import multiprocessing.dummy
+import re
 from operator import itemgetter
 
 from six import raise_from
@@ -70,6 +71,7 @@ def find_datasets(
         detector=None,
         type=None,
         segment=None,
+        match=None,
         host=api.DEFAULT_URL,
 ):
     """Find datasets available on the given GW open science host
@@ -86,6 +88,9 @@ def find_datasets(
     segment : 2-`tuple` of `int`, `None`, optional
         a GPS ``[start, stop)`` interval to restrict matches to;
         datasets will match if they overlap at any point
+
+    match : `str`, optional
+        regular expression string against which to match datasets
 
     host : `str`, optional
         the URL of the LOSC host to query, defaults to losc.ligo.org
@@ -149,6 +154,10 @@ def find_datasets(
             # record events
             if needevents:
                 names.update(events)
+
+    if match:
+        reg = re.compile(match)
+        return sorted(filter(reg.match, names))
 
     return sorted(names)
 

--- a/gwosc/tests/test_datasets.py
+++ b/gwosc/tests/test_datasets.py
@@ -92,6 +92,11 @@ def test_find_datasets_segment():
     assert "GW170817" not in sets
 
 
+@pytest.mark.remote
+def test_find_datasets_match():
+    assert "O1" not in datasets.find_datasets(match="GW")
+
+
 @mock.patch('gwosc.api.fetch_dataset_json', return_value=DATASET_JSON)
 @mock.patch('gwosc.api.fetch_catalog_json', return_value=CATALOG_JSON)
 @mock.patch(


### PR DESCRIPTION
This PR adds the `match=<regexp>` keyword to `gwosc.datasets.find_datasets`, to filter returned datasets by regular expression.