### PR TITLE
Use python3_pkgversion macro in gwosc.spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ aliases:
           yum -y -q install \
               yum-utils \
               rpm-build \
-              python34 \
-              python3-rpm-macros;
+              python-srpm-macros \
+          ;
           # hack version number
           tar -xf gwosc-*.tar.gz;
           rm -rf gwosc-*.tar.gz;

--- a/gwosc.spec
+++ b/gwosc.spec
@@ -17,6 +17,7 @@ BuildArch: noarch
 
 # rpmbuild dependencies
 BuildRequires: rpm-build
+BuildRequires: python-srpm-macros
 BuildRequires: python2-rpm-macros
 BuildRequires: python3-rpm-macros
 

--- a/gwosc.spec
+++ b/gwosc.spec
@@ -17,21 +17,20 @@ BuildArch: noarch
 
 # rpmbuild dependencies
 BuildRequires: rpm-build
-BuildRequires: python-rpm-macros
 BuildRequires: python2-rpm-macros
 BuildRequires: python3-rpm-macros
 
 # build dependencies
 BuildRequires: python-setuptools
-BuildRequires: python%{python3_version_nodots}-setuptools
+BuildRequires: python%{python3_pkgversion}-setuptools
 
 # runtime dependencies (required for %check)
 BuildRequires: python2-six
-BuildRequires: python%{python3_version_nodots}-six
+BuildRequires: python%{python3_pkgversion}-six
 
 # testing dependencies (required for %check)
 BuildRequires: python2-pytest
-BuildRequires: python%{python3_version_nodots}-pytest
+BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python2-mock
 
 %description
@@ -52,11 +51,11 @@ gravitational-wave observatories.
 
 # -- python-3X-ligotimegps
 
-%package -n python%{python3_version_nodots}-%{name}
+%package -n python%{python3_pkgversion}-%{name}
 Summary:  %{summary}
-Requires: python%{python3_version_nodots}-six
-%{?python_provide:%python_provide python%{python3_version_nodots}-%{name}}
-%description -n python%{python3_version_nodots}-%{name}
+Requires: python%{python3_pkgversion}-six
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
+%description -n python%{python3_pkgversion}-%{name}
 The `gwosc` package provides an interface to querying the open data
 releases hosted on <https://losc.ligo.org> from the LIGO and Virgo
 gravitational-wave observatories.
@@ -90,7 +89,7 @@ rm -rf $RPM_BUILD_ROOT
 %doc README.md
 %{python2_sitelib}/*
 
-%files -n python%{python3_version_nodots}-%{name}
+%files -n python%{python3_pkgversion}-%{name}
 %license LICENSE
 %doc README.md
 %{python3_sitelib}/*

--- a/gwosc.spec
+++ b/gwosc.spec
@@ -1,6 +1,6 @@
 %define name    gwosc
 %define version 0.4.2
-%define release 1
+%define release 2
 
 Name:      %{name}
 Version:   %{version}

--- a/gwosc.spec
+++ b/gwosc.spec
@@ -18,6 +18,7 @@ BuildArch: noarch
 # rpmbuild dependencies
 BuildRequires: rpm-build
 BuildRequires: python-srpm-macros
+BuildRequires: python-rpm-macros
 BuildRequires: python2-rpm-macros
 BuildRequires: python3-rpm-macros
 


### PR DESCRIPTION
This PR patches `gwosc.spec` to use the the `%{python3_pkgversion}` macro, its more robust than `%{python3_version_nodots}`.