### PR TITLE
Fix ValueError when querying for versioned datasets for a detector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,11 @@ aliases:
               dpkg --install ${DEB};
           };
 
+  - &debian_install_git
+      run:
+        name: Install git
+        command: apt-get -yqq install git
+
   - &centos_build
       run:
         name: Build
@@ -124,6 +129,11 @@ aliases:
           fi;
           yum -y --nogpgcheck localinstall ./python${PYXY}-gwosc*.rpm
 
+  - &centos_install_git
+      run:
+        name: Install git
+        command: yum -y -q install git
+
   - &test
       run:
         name: Test
@@ -171,6 +181,7 @@ aliases:
         - *debian_install
         - *test
         - *coverage_report
+        - *debian_install_git
         - *codecov
         - *store_test_results
         - *store_test_artifacts
@@ -184,6 +195,7 @@ aliases:
         - *centos_install
         - *test
         - *coverage_report
+        - *centos_install_git
         - *codecov
         - *store_test_results
         - *store_test_artifacts

--- a/gwosc/tests/test_datasets.py
+++ b/gwosc/tests/test_datasets.py
@@ -95,6 +95,14 @@ def test_find_datasets_match():
 
 
 @pytest.mark.remote
+def test_find_datasets_event_version_detector():
+    # this raises a ValueError with gwosc-0.5.0
+    sets = datasets.find_datasets(type='event', version=1, detector='L1')
+    assert "GW150914" in sets
+    assert "GW150914_R1" not in sets  # v3
+
+
+@pytest.mark.remote
 def test_event_gps():
     assert datasets.event_gps('GW170817') == 1187008882.4
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
With `gwosc-0.5.0` the following results in a `ValueError`:

```pytb
>>> from gwosc import datasets
>>> datasets.find_datasets(type='event', version=1, detector='L1')
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/duncan/git/gwosc/gwosc/datasets.py", line 262, in find_datasets
    return sorted(list(_iter_datasets(
  File "/Users/duncan/git/gwosc/gwosc/datasets.py", line 203, in _iter_datasets
    for name in _matched(_event_datasets(
  File "/Users/duncan/git/gwosc/gwosc/datasets.py", line 183, in _matched
    for x in iter_:
  File "/Users/duncan/git/gwosc/gwosc/datasets.py", line 104, in _event_datasets
    detset = event_detectors(
  File "/Users/duncan/git/gwosc/gwosc/datasets.py", line 461, in event_detectors
    data = _event_metadata(
  File "/Users/duncan/git/gwosc/gwosc/datasets.py", line 282, in _event_metadata
    return list(api._fetch_allevents_event_json(
  File "/Users/duncan/git/gwosc/gwosc/api.py", line 263, in _fetch_allevents_event_json
    raise ValueError(msg)
ValueError: failed to identify catalog for event 'GW150914_R1' at version 1
```

This PR fixes that.

cc @alurban (reporter)