### PR TITLE
Remove universal bdist_wheel option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 test = pytest
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 
 [versioneer]
 VCS = git

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [aliases]
 test = pytest
 
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE
 


### PR DESCRIPTION
This PR updates `setup.cfg`'s options for `bdist_wheel` now that we don't support python2.