### PR TITLE
Fix bug in get_urls() not respecting the dataset version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,12 +283,12 @@ jobs:
     environment:
       PYTHON_VERSION: "3.7"
 
-  debian:bullseye:3.7:
+  debian:bullseye:3.8:
     <<: *debian
     docker:
       - image: debian:bullseye
     environment:
-      PYTHON_VERSION: "3.7"
+      PYTHON_VERSION: "3.8"
 
   python:3.5:
     <<: *python
@@ -350,7 +350,7 @@ workflows:
       - debian:buster:3.7:
           requires:
             - sdist
-      - debian:bullseye:3.7:
+      - debian:bullseye:3.8:
           requires:
             - sdist
       - python:3.5:

--- a/gwosc/locate.py
+++ b/gwosc/locate.py
@@ -148,6 +148,7 @@ def get_urls(
                     end=end,
                     format=format,
                     sample_rate=sample_rate,
+                    version=version,
                 )
 
             # if full span covered, return now

--- a/gwosc/tests/test_locate.py
+++ b/gwosc/tests/test_locate.py
@@ -20,6 +20,7 @@
 """
 
 import os.path
+from pathlib import Path
 
 import pytest
 
@@ -59,6 +60,14 @@ def test_get_urls():
         locate.get_urls(detector, 0, 1)
     with pytest.raises(ValueError):  # no Virgo data for S6
         locate.get_urls('V1', start, end)
+
+
+@pytest.mark.remote
+def test_get_urls_version():
+    """Regression test against version not being respected in get_urls
+    """
+    urls = locate.get_urls('L1', 1187008877, 1187008887, version=2)
+    assert Path(urls[0]).name == "L-L1_LOSC_CLN_4_V1-1187007040-2048.hdf5"
 
 
 @pytest.mark.remote


### PR DESCRIPTION
This PR fixes a bug where the dataset version isn't respected in calls to `get_urls`. This may only impact corner cases where the dataset name for an old version matches the `commonName` where a more advanced version exists - in which case before this patch the latest version is always returned.