### PR TITLE
fixed needevents so find_datasets would work

### DIFF
--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -230,7 +230,7 @@ def _iter_datasets(
             segment=segment,
             host=host,
             version=version,
-            catalog=catalog
+            catalog=catalog,
         )):
             yield name
 

--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -226,11 +226,11 @@ def _iter_datasets(
 
     if needevents:
         for name in _matched(_event_datasets(
-            detector = detector,
-            segment = segment,
-            host = host,
-            version = version,
-            catalog = catalog
+            detector=detector,
+            segment=segment,
+            host=host,
+            version=version,
+            catalog=catalog
         )):
             yield name
 

--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -226,11 +226,11 @@ def _iter_datasets(
 
     if needevents:
         for name in _matched(_event_datasets(
-            detector=detector,
-            segment=segment,
-            host=host,
-            version=version,
-            catalog=catalog
+            detector = detector,
+            segment = segment,
+            host = host,
+            version = version,
+            catalog = catalog
         )):
             yield name
 

--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -230,6 +230,7 @@ def _iter_datasets(
             segment=segment,
             host=host,
             version=version,
+            catalog=catalog
         )):
             yield name
 


### PR DESCRIPTION
find_events wasn't working correctly when passed catalog. For example: find_datasets(catalog='GWTC-1-confident',type='events') would just return all events. The needevents function was just missing catalog=catalog. 