### PR TITLE
Updates for new gwosc event naming convention

### DIFF
--- a/gwosc/api.py
+++ b/gwosc/api.py
@@ -25,7 +25,6 @@ import contextlib
 import json
 import logging
 import os
-import re
 from urllib.request import urlopen
 
 logger = logging.getLogger("gwosc.api")
@@ -37,7 +36,6 @@ logger.addHandler(_loghandler)
 logger.setLevel(int(os.getenv("GWOSC_LOG_LEVEL", logging.NOTSET)))
 
 _MAX_GPS = 99999999999
-_VERSIONED_EVENT_REGEX = re.compile(r"_[RV]\d+\Z")
 
 #: The default GWOSC host URL
 DEFAULT_URL = "https://www.gw-openscience.org"

--- a/gwosc/tests/test_api.py
+++ b/gwosc/tests/test_api.py
@@ -46,8 +46,8 @@ def test_fetch_json():
     url = 'https://www.gw-openscience.org/archive/1126257414/1126261510/json/'
     out = api.fetch_json(url)
     assert isinstance(out, dict)
-    assert len(out['events']) == 1
-    assert sorted(out['events']['GW150914']['detectors']) == ['H1', 'L1']
+    assert len(out['events']) == 3
+    assert sorted(out['events']['GW150914-v1']['detectors']) == ['H1', 'L1']
     assert set(out['runs'].keys()).issubset(
         {'tenyear', 'O1', 'O1_16KHZ', 'history'},
     )
@@ -125,7 +125,7 @@ def test_fetch_cataloglist_json_local(fetch):
 def test_fetch_catalog_json():
     out = api.fetch_catalog_json("GWTC-1-confident")
     events = out["events"]
-    assert events["GW170817_R1"]["GPS"] == 1187008882.4
+    assert events["GW170817-v3"]["GPS"] == 1187008882.4
 
 
 @mock.patch("gwosc.api.fetch_json")
@@ -139,14 +139,14 @@ def test_fetch_catalog_json_local(fetch):
 @pytest.mark.remote
 def test_fetch_event_json():
     out = api.fetch_event_json("GW150914")
-    meta = out["events"]["GW150914_R1"]
+    meta = out["events"]["GW150914-v3"]
     assert int(meta["GPS"]) == 1126259462
     assert meta["version"] == 3
 
 
 @pytest.mark.remote
 def test_fetch_event_json_version():
-    out = api.fetch_event_json("GW150914_R1")["events"]["GW150914_R1"]
+    out = api.fetch_event_json("GW150914-v3")["events"]["GW150914-v3"]
     assert out["version"] == 3
     assert out["catalog.shortName"] == "GWTC-1-confident"
 
@@ -154,8 +154,8 @@ def test_fetch_event_json_version():
 @pytest.mark.remote
 def test_fetch_event_json_error():
     with pytest.raises(ValueError):
-        api.fetch_event_json("GW150914_R1", version=1)
+        api.fetch_event_json("GW150914-v3", version=1)
     with pytest.raises(ValueError):
-        api.fetch_event_json("GW150914_R1", catalog="test")
+        api.fetch_event_json("GW150914-v3", catalog="test")
     with pytest.raises(ValueError):
         api.fetch_event_json("blah")

--- a/gwosc/tests/test_datasets.py
+++ b/gwosc/tests/test_datasets.py
@@ -56,7 +56,7 @@ CATALOG_JSON = {
 @pytest.mark.remote
 def test_find_datasets():
     sets = datasets.find_datasets()
-    for dset in ('S6', 'O1', 'GW150914', 'GW170817'):
+    for dset in ('S6', 'O1', 'GW150914-v1', 'GW170817-v3'):
         assert dset in sets
     assert 'tenyear' not in sets
     assert 'history' not in sets
@@ -65,8 +65,8 @@ def test_find_datasets():
 @pytest.mark.remote
 def test_find_datasets_detector():
     v1sets = datasets.find_datasets('V1')
-    assert 'GW170817' in v1sets
-    assert 'GW150914' not in v1sets
+    assert 'GW170817-v3' in v1sets
+    assert 'GW150914-v1' not in v1sets
 
     assert datasets.find_datasets('X1', type="run") == []
 
@@ -85,7 +85,7 @@ def test_find_datasets_type():
 @pytest.mark.remote
 def test_find_datasets_segment():
     sets = datasets.find_datasets(segment=(1126051217, 1137254417))
-    assert "GW150914" in sets
+    assert "GW150914-v1" in sets
     assert "GW170817" not in sets
 
 
@@ -98,8 +98,8 @@ def test_find_datasets_match():
 def test_find_datasets_event_version_detector():
     # this raises a ValueError with gwosc-0.5.0
     sets = datasets.find_datasets(type='event', version=1, detector='L1')
-    assert "GW150914" in sets
-    assert "GW150914_R1" not in sets  # v3
+    assert "GW150914-v1" in sets
+    assert "GW150914-v3" not in sets  # v3
 
 
 @pytest.mark.remote
@@ -233,7 +233,7 @@ def test_run_at_gps_local():
 @pytest.mark.remote
 def test_dataset_type():
     assert datasets.dataset_type("O1") == "run"
-    assert datasets.dataset_type("GW150914") == "event"
+    assert datasets.dataset_type("GW150914-v1") == "event"
     assert datasets.dataset_type("GWTC-1-confident") == "catalog"
     with pytest.raises(ValueError):
         datasets.dataset_type("invalid")

--- a/gwosc/tests/test_locate.py
+++ b/gwosc/tests/test_locate.py
@@ -49,7 +49,7 @@ def test_get_urls():
     # test fetch for GW170817 data
     assert len(locate.get_urls(
         'L1', 1187007040, 1187009088,
-        dataset="GW170817",
+        dataset="GW170817-v3",
     )) == 2
 
     # test for O1 data
@@ -84,7 +84,7 @@ def test_get_urls_deprecated_tag():
 
 @pytest.mark.remote
 def test_get_event_urls():
-    urls = locate.get_event_urls("GW150914_R1", sample_rate=4096)
+    urls = locate.get_event_urls("GW150914-v3", sample_rate=4096)
     assert len(urls) == 4
     for url in urls:
         assert "_4KHZ" in url
@@ -93,7 +93,7 @@ def test_get_event_urls():
 @pytest.mark.remote
 def test_get_event_urls_segment():
     urls = locate.get_event_urls(
-        "GW150914_R1",
+        "GW150914-v1",
         start=1126257415,
         end=1126257425,
     )


### PR DESCRIPTION
This PR updates this library to accommodate changes in the upstream GWOSC API, most notably the renaming of event datasets. This changes is mainly updating the test suite to use the newer dataset names, but also requires a change to the timeline interface to only look at `run` datasets.