### PR TITLE
Finalise release: 0.5.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gwosc (0.5.5-1) unstable; urgency=low
+
+  * update to 0.5.5
+
+ -- Duncan Macleod <duncan.macleod@ligo.org>  Mon, 27 Jul 2020 14:23:00 +0100
+
 gwosc (0.5.4-1) unstable; urgency=low
 
   * update to 0.5.4

--- a/gwosc.spec
+++ b/gwosc.spec
@@ -1,5 +1,5 @@
 %define name    gwosc
-%define version 0.5.4
+%define version 0.5.5
 %define release 1
 
 Name:      %{name}
@@ -71,6 +71,9 @@ rm -rf $RPM_BUILD_ROOT
 # -- changelog
 
 %changelog
+* Mon Jul 27 2020 Duncan Macleod <duncan.macleod@ligo.org> - 0.5.5-1
+- update to 0.5.5
+
 * Sun Jul 26 2020 Duncan Macleod <duncan.macleod@ligo.org> - 0.5.4-1
 - update to 0.5.4
 


### PR DESCRIPTION
This PR finalises the 0.5.5 release, which is just a re-release of 0.5.4 to try and fix a pypi issue.