### PR TITLE
Use requests instead of urllib for remote connections

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,9 +12,12 @@ X-Python3-Version: >= 3.5
 Build-Depends:
   debhelper (>= 9),
   dh-python,
+  lsb-release,
   python3-all,
-  python3-setuptools,
   python3-pytest,
+  python3-requests,
+  python3-requests-mock,
+  python3-setuptools,
 
 # -- python3-gwosc -------------------------------------------------------------
 
@@ -23,6 +26,7 @@ Architecture: all
 Depends:
   ${misc:Depends},
   ${python3:Depends},
+  python3-requests,
 Description: A python3 interface to the Gravitational-Wave Open Science Center data archive
  The `gwosc` package provides an interface to querying the open data
  releases hosted on <https://gw-openscience.org> from the GEO, LIGO,

--- a/debian/rules
+++ b/debian/rules
@@ -1,11 +1,20 @@
 #!/usr/bin/make -f
 
+include /usr/share/dpkg/pkg-info.mk
+
 export PYBUILD_NAME = gwosc
 
 # use pytest for tests
 export PYBUILD_TEST_PYTEST = 1
+
 # but don't run tests requiring network
 export PYBUILD_TEST_ARGS = -m 'not remote'
+
+# but skip all tests if debian stretch (can't satisfy requests-mock >=1.5.0)
+DEB_CODENAME = $(shell lsb_release --codename --short)
+ifneq (,$(findstring stretch,$(DEB_CODENAME)))
+export PYBUILD_DISABLE = test
+endif
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,5 +8,4 @@
    :class: h2
 
 .. automodsumm:: gwosc.api
-   :skip: urlopen
    :toctree: reference

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,6 +106,7 @@ html_sidebars = {
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'https://docs.python.org/': None,
+    'https://requests.readthedocs.io/en/stable/': None,
 }
 
 # Write automodsumm files to /docs/reference/

--- a/gwosc.spec
+++ b/gwosc.spec
@@ -26,10 +26,13 @@ BuildRequires: python3-rpm-macros
 BuildRequires: python%{python3_pkgversion}-setuptools
 
 # runtime dependencies (required for %check)
-# NONE
+BuildRequires: python%{python3_pkgversion}-requests
 
 # testing dependencies (required for %check)
+%if 0%{?rhel} == 0 || 0%{?rhel} >= 8
 BuildRequires: python%{python3_pkgversion}-pytest
+BuildRequires: python%{python3_pkgversion}-requests-mock >= 1.5.0
+%endif
 
 %description
 The `gwosc` package provides an interface to querying the open data
@@ -55,7 +58,9 @@ and Virgo gravitational-wave observatories.
 %py3_build
 
 %check
+%if 0%{?rhel} == 0 || 0%{?rhel} >= 8
 %{__python3} -m pytest --pyargs %{name} -m "not remote"
+%endif
 
 %install
 %py3_install

--- a/gwosc/tests/test_api.py
+++ b/gwosc/tests/test_api.py
@@ -20,7 +20,6 @@
 """
 
 import os.path
-from io import BytesIO
 from unittest import mock
 
 import pytest
@@ -60,9 +59,12 @@ def test_fetch_json():
         "Failed to parse LOSC JSON from {!r}: ".format(url2))
 
 
-@mock.patch('gwosc.api.urlopen', return_value=BytesIO(b'{"key": "value"}'))
-def test_fetch_json_local(_):
-    url = 'anything'
+def test_fetch_json_local(requests_mock):
+    url = 'http://anything'
+    requests_mock.get(
+        url,
+        json={"key": "value"},
+    )
     out = api.fetch_json(url)
     assert isinstance(out, dict)
     assert out['key'] == 'value'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pytest >= 2.7.0
 pytest-cov
 pytest-socket
+requests >= 1.0.0
+requests-mock >= 1.5.0
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,13 @@ setup_requires = []
 if {'test'}.intersection(sys.argv):
     setup_requires.append('pytest_runner')
 install_requires = [
+    'requests>=1.0.0',
 ]
 tests_require = [
     'pytest>=2.7.0',
     'pytest-cov',
     'pytest-socket',
+    'requests-mock>=1.5.0',
 ]
 extras_require = {
     'docs': [


### PR DESCRIPTION
This PR modifies the `gwosc.api.fetch_json` function (the only thing that actually does any remote data access) to use `requests.get` instead of `urllib.request.urlopen` - it handles certificates and a bunch of other things better.

This actually resolves the appveyor issues that prompted #48,#50 in the first place.

This should resolve issues in the gwpy appveyor builds.