### PR TITLE
Update tests to reflect upstream changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,12 +272,12 @@ jobs:
     environment:
       PYTHON_VERSION: "3.7"
 
-  debian:bullseye:3.8:
+  debian:bullseye:3.9:
     <<: *debian
     docker:
       - image: debian:bullseye
     environment:
-      PYTHON_VERSION: "3.8"
+      PYTHON_VERSION: "3.9"
 
   sphinx:
     docker:
@@ -311,7 +311,7 @@ workflows:
       - debian:buster:3.7:
           requires:
             - sdist
-      - debian:bullseye:3.8:
+      - debian:bullseye:3.9:
           requires:
             - sdist
       - sphinx

--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -58,6 +58,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 _IGNORE = {
     "tenyear",
     "history",
+    "oldhistory",
 }
 
 

--- a/gwosc/tests/test_api.py
+++ b/gwosc/tests/test_api.py
@@ -47,9 +47,7 @@ def test_fetch_json():
     assert isinstance(out, dict)
     assert len(out['events']) == 3
     assert sorted(out['events']['GW150914-v1']['detectors']) == ['H1', 'L1']
-    assert set(out['runs'].keys()).issubset(
-        {'tenyear', 'O1', 'O1_16KHZ', 'history'},
-    )
+    assert {'tenyear', 'O1', 'O1_16KHZ', 'history'}.issubset(set(out['runs']))
 
     # check errors (use legit URL that isn't JSON)
     url2 = os.path.dirname(os.path.dirname(url))
@@ -76,7 +74,7 @@ def test_fetch_dataset_json():
     end = 934100000
     out = api.fetch_dataset_json(start, end)
     assert not out['events']
-    assert set(out['runs'].keys()).issubset({'tenyear', 'S6', 'history'})
+    assert {"tenyear", "S6", "history"}.issubset(set(out['runs']))
 
 
 @mock.patch('gwosc.api.fetch_json')

--- a/gwosc/tests/test_datasets.py
+++ b/gwosc/tests/test_datasets.py
@@ -75,7 +75,9 @@ def test_find_datasets_detector():
 def test_find_datasets_type():
     runsets = datasets.find_datasets(type='run')
     assert 'O1' in runsets
-    run_regex = re.compile(r'\A([OS]\d+|BKGW\d{6})(_\d+KHZ)?(_[RV]\d+)?\Z')
+    run_regex = re.compile(
+        r'\A([OS]\d+([a-z])?|BKGW\d{6})(_\d+KHZ)?(_[RV]\d+)?\Z',
+    )
     for dset in runsets:
         assert run_regex.match(dset)
 


### PR DESCRIPTION
This PR updates the test suite (and one library reference) to reflect changes made upstream on the gw-openscience.org API.