### PR TITLE
Add a CI build job that disables remote tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   conda:
-    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
+    name: ${{ matrix.name || format('Python {0} ({1})', matrix.python-version, matrix.os) }}
 
     strategy:
       fail-fast: false
@@ -38,6 +38,11 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+        include:
+          - os: Ubuntu
+            name: "Disable socket"
+            python-version: "3"
+            pytest-addopts: "--disable-socket -m 'not remote'"
     runs-on: ${{ matrix.os }}-latest
 
     # this is needed for conda environments to activate automatically
@@ -93,6 +98,8 @@ jobs:
       run: conda list --name test
 
     - name: Run test suite
+      env:
+        PYTEST_ADDOPTS: ${{ matrix.pytest-addopts }}
       run: python -m pytest -ra --color yes --cov gwosc --pyargs gwosc --cov-report=xml --junitxml=pytest.xml
 
     - name: Coverage report

--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -71,7 +71,7 @@ def _run_datasets(detector=None, segment=None, host=api.DEFAULT_URL):
 
 
 def _catalog_datasets(host=api.DEFAULT_URL):
-    return api.fetch_cataloglist_json(host=host).keys()
+    yield from api.fetch_cataloglist_json(host=host).keys()
 
 
 def _match_event_dataset(


### PR DESCRIPTION
This PR adds a job to the build matrix to disable remote tests - hopefully this is a faithful simulation of what happens in real-world Debian and RPM build platforms.