### PR TITLE
Add support for referencing GWYYMMDD_HHMMSS just by the date prefix

### DIFF
--- a/gwosc/api.py
+++ b/gwosc/api.py
@@ -226,7 +226,11 @@ def _fetch_allevents_event_json(
 
     def _match(keyvalue):
         dset, metadata = keyvalue
-        if event not in {dset, metadata["commonName"]}:
+        if event not in {
+            dset,
+            metadata["commonName"],  # full name
+            metadata["commonName"].split("_", 1)[0],  # GWYYMMDD prefix
+        }:
             return
         if version is not None and metadata["version"] != version:
             return
@@ -235,11 +239,19 @@ def _fetch_allevents_event_json(
         return True
 
     matched = list(filter(_match, allevents.items()))
-    if matched:
+    names = set(x[1]["commonName"] for x in matched)
+    if matched and len(names) == 1:
         key, meta = sorted(matched, key=lambda x: x[1]["version"])[-1]
         return {"events": {key: meta}}
 
     # raise error with the right message
+    if len(names) > 1:
+        raise ValueError(
+            "multiple events matched for {!r}: '{}'".format(
+                event,
+                "', '".join(names),
+            ),
+        )
     msg = "failed to identify {} for event '{}'"
     if catalog is None:
         msg = msg.format("catalog", event)

--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -330,17 +330,13 @@ def event_gps(event, catalog=None, version=None, host=api.DEFAULT_URL):
     >>> event_gps('GW123456')
     ValueError: no event dataset found for 'GW123456'
     """
-    try:
-        return _event_metadata(
-            event,
-            catalog=catalog,
-            version=version,
-            full=False,
-            host=host,
-        )['GPS']
-    except ValueError as exc:
-        exc.args = ("no event dataset found for {!r}".format(event),)
-        raise
+    return _event_metadata(
+        event,
+        catalog=catalog,
+        version=version,
+        full=False,
+        host=host,
+    )['GPS']
 
 
 def event_segment(

--- a/gwosc/tests/test_api.py
+++ b/gwosc/tests/test_api.py
@@ -131,6 +131,12 @@ def test_fetch_event_json():
 
 
 @pytest.mark.remote
+def test_fetch_event_json_with_hms_suffix():
+    out = api.fetch_event_json("GW190930")
+    assert list(out["events"].values())[0]["commonName"] == "GW190930_133541"
+
+
+@pytest.mark.remote
 def test_fetch_event_json_version():
     out = api.fetch_event_json("GW150914-v3")["events"]["GW150914-v3"]
     assert out["version"] == 3
@@ -138,10 +144,25 @@ def test_fetch_event_json_version():
 
 
 @pytest.mark.remote
-def test_fetch_event_json_error():
+def test_fetch_event_json_error_no_version():
     with pytest.raises(ValueError):
         api.fetch_event_json("GW150914-v3", version=1)
+
+
+@pytest.mark.remote
+def test_fetch_event_json_error_no_catalog():
     with pytest.raises(ValueError):
         api.fetch_event_json("GW150914-v3", catalog="test")
+
+
+@pytest.mark.remote
+def test_fetch_event_json_error_not_found():
     with pytest.raises(ValueError):
         api.fetch_event_json("blah")
+
+
+@pytest.mark.remote
+def test_fetch_event_json_error_multiple_names():
+    with pytest.raises(ValueError) as exc:
+        api.fetch_event_json("GW190521")
+    assert str(exc.value).startswith("multiple events matched for 'GW190521'")

--- a/gwosc/tests/test_datasets.py
+++ b/gwosc/tests/test_datasets.py
@@ -99,9 +99,6 @@ def test_find_datasets_warning(_):
 @pytest.mark.remote
 def test_event_gps():
     assert datasets.event_gps('GW170817') == 1187008882.4
-    with pytest.raises(ValueError) as exc:
-        datasets.event_gps('GW123456')
-    assert str(exc.value) == 'no event dataset found for \'GW123456\''
 
 
 @mock.patch(
@@ -113,10 +110,6 @@ def test_event_gps():
 )
 def test_event_gps_local(fetch):
     assert datasets.event_gps('GW150914') == 12345
-    fetch.side_effect = ValueError('test')
-    with pytest.raises(ValueError) as exc:
-        datasets.event_gps('something')
-    assert str(exc.value) == "no event dataset found for 'something'"
 
 
 @pytest.mark.remote


### PR DESCRIPTION
This PR add support for matching datasets just by the `GWYYMMDD` prefix, so that users don't need to pass the `_HHMMSS` suffix. If multiple events are found on the same day, an error is returned.