### PR TITLE
Ignore warnings from readline in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ write_to = "gwosc/_version.py"
 addopts = "-r a --color=yes"
 filterwarnings = [
 	"error",
+	# https://github.com/pyreadline/pyreadline/issues/65
+	"ignore:Using or importing the ABCs::pyreadline",
 ]
 markers = [
 	"remote",


### PR DESCRIPTION
This PR updates the pytest configuration in pyproject.toml to ignore a `DeprecationWarning` emitted from `pyreadline`. See https://github.com/pyreadline/pyreadline/issues/65.