### PR TITLE
Simplify dataset handling in get_urls and allow partial matches

### DIFF
--- a/gwosc/locate.py
+++ b/gwosc/locate.py
@@ -97,22 +97,15 @@ def get_urls(
             DeprecationWarning,
         )
 
-    if dataset:
-        dstypes = (datasets.dataset_type(dataset),)
-    else:
-        dstypes = ("event", "run")
-
-    for dstype in dstypes:
-        if dataset:
-            dsets = [dataset]
-        else:
-            dsets = datasets._iter_datasets(
-                type=dstype,
-                detector=detector,
-                segment=(start, end),
-                version=version,
-                host=host,
-            )
+    for dstype in ("event", "run"):
+        dsets = datasets._iter_datasets(
+            match=dataset,
+            type=dstype,
+            detector=detector,
+            segment=(start, end),
+            version=version,
+            host=host,
+        )
 
         for dst in dsets:
             # get URL list for this dataset


### PR DESCRIPTION
This PR simplifies `gwosc.locate.get_urls` handling of datasets to enable users to supply a partial match to a dataset in the named argument.

The upshot of this is that the following command that used to fail:

```pytb
❯ python -c "from gwosc.locate import get_urls; print(get_urls('H1', 1187006834, 1187006835, dataset='O2'))"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\spxdmm\git\gwosc\gwosc\locate.py", line 101, in get_urls
    dstypes = (datasets.dataset_type(dataset),)
  File "C:\Users\spxdmm\git\gwosc\gwosc\datasets.py", line 587, in dataset_type
    raise ValueError(
ValueError: failed to determine type for dataset 'O2'
```

now matches `O2` to the relevant dataset:

```pytb
❯ python -c "from gwosc.locate import get_urls; print(get_urls('H1', 1187006834, 1187006835, dataset='O2'))"
['https://www.gw-openscience.org/archive/data/O2_4KHZ_R1/1186988032/H-H1_GWOSC_O2_4KHZ_R1-1187004416-4096.hdf5']
```

cc @camurria