### PR TITLE
Update all 'LOSC' references to 'GWOSC'

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = python -msphinx
-SPHINXPROJ    = PyLOSC
+SPHINXPROJ    = gwosc
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/gwosc/api.py
+++ b/gwosc/api.py
@@ -64,7 +64,7 @@ def fetch_json(url, **kwargs):
                 resp.json(),
             )
         except ValueError as exc:
-            exc.args = ("Failed to parse LOSC JSON from %r: %s"
+            exc.args = ("Failed to parse GWOSC JSON from %r: %s"
                         % (url, str(exc)),)
             raise
 
@@ -87,12 +87,13 @@ def fetch_dataset_json(gpsstart, gpsend, host=DEFAULT_URL):
         the GPS end of the desired interval
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------
     data : `dict` or `list`
-        the JSON data retrieved from LOSC and returned by `json.loads`
+        the JSON data retrieved from GWOSC and returned by `json.loads`
     """
     return fetch_json(_dataset_url(gpsstart, gpsend, host=host))
 
@@ -122,12 +123,13 @@ def fetch_run_json(run, detector, gpsstart=0, gpsend=_MAX_GPS,
         the GPS end of the desired interval
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------
     data : `dict` or `list`
-        the JSON data retrieved from LOSC and returned by `json.loads`
+        the JSON data retrieved from GWOSC and returned by `json.loads`
     """
     return fetch_json(_run_url(run, detector, gpsstart, gpsend, host=host))
 
@@ -169,7 +171,8 @@ def fetch_catalog_json(catalog, host=DEFAULT_URL):
         the name of the event catalog, e.g. `GWTC-1-confident`
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------
@@ -196,7 +199,7 @@ def fetch_allevents_json(full=False, host=DEFAULT_URL):
     Parameters
     ----------
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to gw-openscience.org
+        the URL of the GWOSC host to query, defaults to gw-openscience.org
 
     Returns
     -------
@@ -291,12 +294,13 @@ def fetch_event_json(
         restrict query to a given data-release version
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------
     data : `dict` or `list`
-        the JSON data retrieved from LOSC and returned by `json.loads`
+        the JSON data retrieved from GWOSC and returned by `json.loads`
     """
     return fetch_json(
         _event_url(event, catalog=catalog, version=version, host=host),
@@ -320,7 +324,8 @@ def fetch_legacy_catalog_json(catalog, host=DEFAULT_URL):
         the name of the event catalog, e.g. `GWTC-1-confident`
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------

--- a/gwosc/datasets.py
+++ b/gwosc/datasets.py
@@ -249,7 +249,8 @@ def find_datasets(
         regular expression string against which to match datasets
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------
@@ -315,7 +316,8 @@ def event_gps(event, catalog=None, version=None, host=api.DEFAULT_URL):
         defaults to the highest available version
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------
@@ -368,7 +370,8 @@ def event_segment(
         defaults to the highest available version
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------
@@ -411,7 +414,8 @@ def event_at_gps(gps, host=api.DEFAULT_URL, tol=1):
         The GPS time to locate
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     tol : `float`, optional
         the search window (in seconds), default: ``1``
@@ -451,7 +455,8 @@ def event_detectors(event, catalog=None, version=None, host=api.DEFAULT_URL):
         the name of the event to query
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     version : `int`, `None`, optional
         the version of the data release to use,
@@ -490,7 +495,8 @@ def run_segment(run, host=api.DEFAULT_URL):
         the name of the run dataset to query
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------
@@ -524,7 +530,8 @@ def run_at_gps(gps, host=api.DEFAULT_URL):
         The GPS time to locate
 
     host : `str`, optional
-        the URL of the LOSC host to query, defaults to losc.ligo.org
+        the URL of the GWOSC host to query, defaults to
+        https://www.gw-openscience.org
 
     Returns
     -------
@@ -563,7 +570,7 @@ def dataset_type(dataset, host=api.DEFAULT_URL):
         The name of the dataset to match
 
     host : `str`, optional
-        the URL of the LOSC host to query
+        the URL of the GWOSC host to query
 
     Returns
     -------

--- a/gwosc/locate.py
+++ b/gwosc/locate.py
@@ -10,19 +10,25 @@ You can search for remote data URLS based on the event name:
 
 >>> from gwosc.locate import get_event_urls
 >>> get_event_urls('GW150914')
-['https://losc.ligo.org//s/events/GW150914/H-H1_LOSC_4_V2-1126259446-32.hdf5', 'https://losc.ligo.org//s/events/GW150914/L-L1_LOSC_4_V2-1126259446-32.hdf5', 'https://losc.ligo.org//s/events/GW150914/H-H1_LOSC_4_V2-1126257414-4096.hdf5', 'https://losc.ligo.org//s/events/GW150914/L-L1_LOSC_4_V2-1126257414-4096.hdf5']
+['https://www.gw-openscience.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126259447-32.hdf5',
+ 'https://www.gw-openscience.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126257415-4096.hdf5',
+ 'https://www.gw-openscience.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126259447-32.hdf5',
+ 'https://www.gw-openscience.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126257415-4096.hdf5']
 
 You can down-select the URLs using keyword arguments:
 
 >>> get_event_urls('GW150914', detector='L1', duration=32)
-['https://losc.ligo.org//s/events/GW150914/L-L1_LOSC_4_V2-1126259446-32.hdf5']
+['https://www.gw-openscience.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126259447-32.hdf5']
 
 You can search for remote data URLs based on the GPS time interval as
 follows:
 
 >>> from gwosc.locate import get_urls
 >>> get_urls('L1', 968650000, 968660000)
-['https://losc.ligo.org/archive/data/S6/967835648/L-L1_LOSC_4_V1-968646656-4096.hdf5', 'https://losc.ligo.org/archive/data/S6/967835648/L-L1_LOSC_4_V1-968650752-4096.hdf5', 'https://losc.ligo.org/archive/data/S6/967835648/L-L1_LOSC_4_V1-968654848-4096.hdf5', 'https://losc.ligo.org/archive/data/S6/967835648/L-L1_LOSC_4_V1-968658944-4096.hdf5']
+['https://www.gw-openscience.org/archive/data/S6/967835648/L-L1_LOSC_4_V1-968646656-4096.hdf5',
+ 'https://www.gw-openscience.org/archive/data/S6/967835648/L-L1_LOSC_4_V1-968650752-4096.hdf5',
+ 'https://www.gw-openscience.org/archive/data/S6/967835648/L-L1_LOSC_4_V1-968654848-4096.hdf5',
+ 'https://www.gw-openscience.org/archive/data/S6/967835648/L-L1_LOSC_4_V1-968658944-4096.hdf5']
 
 By default, this method will return the paths to HDF5 files for the 4 kHz
 sample-rate data, these can be specified as keyword arguments.
@@ -77,7 +83,7 @@ def get_urls(
         the file format (extension) you want to find
 
     host : `str`, optional
-        the URL of the remote LOSC server
+        the URL of the remote GWOSC server
 
     Returns
     -------
@@ -141,7 +147,7 @@ def get_urls(
             if utils.full_coverage(urls, (start, end)):
                 return urls
 
-    raise ValueError("Cannot find a LOSC dataset for %s covering [%d, %d)"
+    raise ValueError("Cannot find a GWOSC dataset for %s covering [%d, %d)"
                      % (detector, start, end))
 
 
@@ -177,7 +183,7 @@ def get_run_urls(
         the sampling rate (Hz) of files you want to find
 
     host : `str`, optional
-        the URL of the remote LOSC server
+        the URL of the remote GWOSC server
 
     version : `int`, `None`, optional
         the data-release version for the selected datasets
@@ -235,7 +241,7 @@ def get_event_urls(
         the sampling rate (Hz) of files you want to find
 
     host : `str`, optional
-        the URL of the remote LOSC server
+        the URL of the remote GWOSC server
 
     start : `int`
         the GPS start time of your query

--- a/gwosc/tests/test_api.py
+++ b/gwosc/tests/test_api.py
@@ -40,7 +40,7 @@ def test_fetch_json():
     with pytest.raises(ValueError) as exc:
         api.fetch_json(url2)
     assert str(exc.value).startswith(
-        "Failed to parse LOSC JSON from {!r}: ".format(url2))
+        "Failed to parse GWOSC JSON from {!r}: ".format(url2))
 
 
 def test_fetch_json_local(requests_mock):

--- a/gwosc/tests/test_urls.py
+++ b/gwosc/tests/test_urls.py
@@ -66,7 +66,7 @@ def test_match_local(mock_urls):
 def test_match_local_tag_error(mock_urls):
     with pytest.raises(ValueError) as exc:
         gwosc_urls.match(mock_urls)
-    assert str(exc.value).startswith('multiple LOSC URL tags')
+    assert str(exc.value).startswith('multiple GWOSC URL tags')
 
 
 def test_match_empty():

--- a/gwosc/timeline.py
+++ b/gwosc/timeline.py
@@ -40,7 +40,7 @@ def get_segments(flag, start, end, host=api.DEFAULT_URL):
         the GPS end time of your query
 
     host : `str`, optional
-        the URL of the remote LOSC server
+        the URL of the remote GWOSC server
 
     Returns
     -------

--- a/gwosc/urls.py
+++ b/gwosc/urls.py
@@ -10,7 +10,7 @@ from os.path import (basename, splitext)
 
 from .utils import segments_overlap
 
-# LOSC filename re
+# GWOSC filename re
 URL_REGEX = re.compile(
     r"\A((.*/)*(?P<obs>[^/]+)-"
     r"(?P<ifo>[A-Z][0-9])_(L|GW)OSC_"
@@ -26,7 +26,7 @@ VERSION_REGEX = re.compile(r'[RV]\d+')
 
 
 def sieve(urllist, segment=None, **match):
-    """Sieve a list of LOSC URL metadata dicts based on key, value pairs
+    """Sieve a list of GWOSC URL metadata dicts based on key, value pairs
 
     Parameters
     ----------
@@ -134,7 +134,7 @@ def match(
         duration=None,
         ext=None,
 ):
-    """Match LOSC URLs for a given [start, end) interval
+    """Match GWOSC URLs for a given [start, end) interval
 
     Parameters
     ----------
@@ -198,7 +198,7 @@ def match(
     # if multiple file tags found, and user didn't specify, error
     if len(matched_tags) > 1:
         tags = ', '.join(map(repr, matched_tags))
-        raise ValueError("multiple LOSC URL tags discovered in dataset, "
+        raise ValueError("multiple GWOSC URL tags discovered in dataset, "
                          "please select one of: {}".format(tags))
 
     # extract highest version


### PR DESCRIPTION
This PR updates all usage of 'LOSC' or losc.ligo.org to the appropriate current branding.