### PR TITLE
Prefer exact matches for events when searching for metadata

### DIFF
--- a/gwosc/api.py
+++ b/gwosc/api.py
@@ -241,9 +241,17 @@ def _fetch_allevents_event_json(
             return
         return True
 
+    # match datasets
     matched = list(filter(_match, allevents.items()))
     names = set(x[1]["commonName"] for x in matched)
-    if matched and len(names) == 1:
+
+    # one dataset has an exact name match, so discard everything else
+    if event in names:
+        matched = [x for x in matched if x[1]["commonName"] == event]
+        names = set(x[1]["commonName"] for x in matched)
+
+    # we have a winner!
+    if len(names) == 1:
         key, meta = sorted(matched, key=lambda x: x[1]["version"])[-1]
         return {"events": {key: meta}}
 

--- a/gwosc/tests/test_api.py
+++ b/gwosc/tests/test_api.py
@@ -162,7 +162,13 @@ def test_fetch_event_json_error_not_found():
 
 
 @pytest.mark.remote
+def test_fetch_event_json_exact_match():
+    data, = list(api.fetch_event_json("GW190521")["events"].values())
+    assert data["commonName"] == "GW190521"
+
+
+@pytest.mark.remote
 def test_fetch_event_json_error_multiple_names():
     with pytest.raises(ValueError) as exc:
-        api.fetch_event_json("GW190521")
-    assert str(exc.value).startswith("multiple events matched for 'GW190521'")
+        api.fetch_event_json("GW190828")
+    assert str(exc.value).startswith("multiple events matched for 'GW190828'")


### PR DESCRIPTION
This PR fixes #73 by explicitly preferring exact matches for event names when searching.

cc @jkanner