### PR TITLE
Update debian builds in CI

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -62,9 +62,9 @@ jobs:
       fail-fast: false
       matrix:
         debian:
-          - stretch-backports
-          - buster
-          - bullseye
+          - oldstable
+          - stable
+          - testing
     runs-on: ubuntu-latest
     container: debian:${{ matrix.debian }}
     env:
@@ -128,9 +128,9 @@ jobs:
       fail-fast: false
       matrix:
         debian:
-          - stretch-backports
-          - buster
-          - bullseye
+          - oldstable
+          - stable
+          - testing
     runs-on: ubuntu-latest
     container: debian:${{ matrix.debian }}
     env:
@@ -195,9 +195,9 @@ jobs:
       fail-fast: false
       matrix:
         debian:
-          - stretch-backports
-          - buster
-          - bullseye
+          - oldstable
+          - stable
+          - testing
     runs-on: ubuntu-latest
     container: debian:${{ matrix.debian }}
     steps:
@@ -221,14 +221,14 @@ jobs:
   lint-debian:
     name: Lint Debian packages
     runs-on: ubuntu-latest
-    container: debian
+    container: debian:stable
     needs:
       - debian-binary
     steps:
       - name: Download debian package
         uses: actions/download-artifact@v2
         with:
-          name: deb-buster
+          name: deb-stable
 
       - name: Install lintian
         run: |

--- a/debian/rules
+++ b/debian/rules
@@ -10,11 +10,5 @@ export PYBUILD_TEST_PYTEST = 1
 # but don't run tests requiring network
 export PYBUILD_TEST_ARGS = --color=yes -m 'not remote'
 
-# but skip all tests if debian stretch (can't satisfy requests-mock >=1.5.0)
-DEB_CODENAME = $(shell lsb_release --codename --short)
-ifneq (,$(findstring stretch,$(DEB_CODENAME)))
-export PYBUILD_DISABLE = test
-endif
-
 %:
 	dh $@ --with python3 --buildsystem=pybuild


### PR DESCRIPTION
This PR updates the debian CI configuration to use the generic names `oldstable`, `stable`, and `testing`, rather than any particular codenames. This hopefully means that things are more future-proof.